### PR TITLE
[BE] test #76: 인메모리 H2를 이용해 CampsiteRepository 테스트

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,18 +1,18 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.2.5'
-    id 'io.spring.dependency-management' version '1.1.4'
+	id 'java'
+	id 'org.springframework.boot' version '3.2.5'
+	id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.d106'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '21'
+	sourceCompatibility = '21'
 }
 
 repositories {
-    mavenCentral()
+	mavenCentral()
 }
 
 dependencies {
@@ -57,17 +57,20 @@ dependencies {
 	// prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus:1.12.5'
 	// test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation(
+		'org.springframework.boot:spring-boot-starter-test',
+		'com.h2database:h2'
+	)
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+	useJUnitPlatform()
 }
 
 bootJar {
-    enabled = true
+	enabled = true
 }
 
 jar {
-    enabled = false
+	enabled = false
 }

--- a/backend/src/main/java/com/d106/campu/auth/constant/RegExpression.java
+++ b/backend/src/main/java/com/d106/campu/auth/constant/RegExpression.java
@@ -4,6 +4,6 @@ public class RegExpression {
 
     public static final String account = "[a-zA-Z0-9]+$";
     public static final String nickname = "[가-힣a-zA-Z0-9]+$";
-    public static final String tel = "[0-9]{2,3}[0-9]{3,4}[0-9]{4}";
+    public static final String tel = "^[0-9]{2,3}[0-9]{3,4}[0-9]{4}$";
 
 }

--- a/backend/src/main/java/com/d106/campu/campsite/domain/jpa/Campsite.java
+++ b/backend/src/main/java/com/d106/campu/campsite/domain/jpa/Campsite.java
@@ -39,7 +39,7 @@ public class Campsite extends BaseTime {
     @Column(name = "faclt_div_nm", length = 16)
     private String facltDivNm;
 
-    @Column(name = "tel", length = 16, unique = true, nullable = false)
+    @Column(name = "tel", length = 11, unique = true, nullable = false)
     private String tel;
 
     @Column(name = "line_intro", length = 512)

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,25 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MariaDBDialect
+        globally_quoted_identifiers: true
+    show-sql: false
+    database-platform: org.hibernate.dialect.MariaDBDialect
+    database: h2
+
+  h2:
+    console:
+      enabled: true

--- a/backend/src/test/java/com/d106/campu/repository/jpa/CampsiteRepositoryTest.java
+++ b/backend/src/test/java/com/d106/campu/repository/jpa/CampsiteRepositoryTest.java
@@ -4,22 +4,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.d106.campu.campsite.domain.jpa.Campsite;
-import com.d106.campu.campsite.dto.CampsiteDto.CreateRequest;
+import com.d106.campu.campsite.dto.CampsiteDto;
 import com.d106.campu.campsite.mapper.CampsiteMapper;
+import com.d106.campu.campsite.mapper.CampsiteMapperImpl;
 import com.d106.campu.campsite.repository.jpa.CampsiteRepository;
 import com.d106.campu.user.domain.jpa.User;
 import com.d106.campu.user.repository.jpa.UserRepository;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
-@SpringBootTest
-@Transactional
+@ActiveProfiles("test")
+@DataJpaTest
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ComponentScan(basePackageClasses = {CampsiteMapper.class, CampsiteMapperImpl.class})
 class CampsiteRepositoryTest {
 
     @Autowired
@@ -31,19 +39,26 @@ class CampsiteRepositoryTest {
     @Autowired
     CampsiteMapper campsiteMapper;
 
+    @DisplayName("테스트 데이터 추가")
     @BeforeEach
-    void 테스트_데이터_추가() {
-        User user = userRepository.save(User.builder()
+    void prepare() {
+        User user = User.builder()
             .account("testuser1")
             .password("testpw1")
             .nickname("user")
-            .tel("01012312311")
-            .build());
+            .tel("01012312310")
+            .build();
 
-        campsiteRepository.save(Campsite.builder()
+        User savedUser = userRepository.save(user);
+        assertThat(savedUser).isEqualTo(user);
+
+        Campsite campsite = Campsite.builder()
             .user(user)
             .facltNm("캠프유캠푸 캠핑장")
-            .build());
+            .tel("01012312310")
+            .build();
+        Campsite savedCampsite = campsiteRepository.save(campsite);
+        assertThat(savedCampsite).isEqualTo(campsite);
     }
 
     @DisplayName("캠핑장 전체 목록 조회")
@@ -57,13 +72,14 @@ class CampsiteRepositoryTest {
     @Test
     public void createCampsite1() {
         // given
-        CreateRequest createRequest = CreateRequest.builder()
+        CampsiteDto.CreateRequest createRequestDto = CampsiteDto.CreateRequest.builder()
             .user(userRepository.findByAccount("testuser1").get())
             .facltNm("캠프유캠푸 캠핑장1")
+            .tel("01012312311")
             .build();
 
         // when
-        Campsite campsite = campsiteMapper.toCampsite(createRequest);
+        Campsite campsite = campsiteMapper.toCampsite(createRequestDto);
         campsiteRepository.save(campsite);
 
         // then
@@ -77,29 +93,29 @@ class CampsiteRepositoryTest {
     @Test
     public void createCampsite2() {
         // given
-        CreateRequest createRequest = CreateRequest.builder()
+        CampsiteDto.CreateRequest createRequestDto = CampsiteDto.CreateRequest.builder()
             .facltNm("캠프유캠푸 캠핑장1")
+            .tel("01012312312")
             .build();
 
         // when
-        Campsite campsite = campsiteMapper.toCampsite(createRequest);
-        assertThatThrownBy(() -> campsiteRepository.save(campsite))
-            .hasMessageContaining("Column 'user_id' cannot be null");
+        Campsite campsite = campsiteMapper.toCampsite(createRequestDto);
+        assertThatThrownBy(() -> campsiteRepository.save(campsite));
     }
 
     @DisplayName("캠핑장 등록 - 실패: 유효성 검사 실패")
     @Test
     public void createCampsite3() {
         // given
-        CreateRequest createRequest1 = CreateRequest.builder()
+        CampsiteDto.CreateRequest createRequestDto = CampsiteDto.CreateRequest.builder()
             .user(userRepository.findByAccount("testuser1").get())
             .facltNm("캠프유캠푸 캠핑장")
             .tel("012345678901")
             .build();
 
         // when
-        Campsite campsite1 = campsiteMapper.toCampsite(createRequest1);
-        assertThatThrownBy(() -> campsiteRepository.save(campsite1))
-            .hasMessageContaining("Data too long for column 'tel' at row 1");
+        Campsite campsite = campsiteMapper.toCampsite(createRequestDto);
+        assertThatThrownBy(() -> campsiteRepository.save(campsite));
     }
+
 }


### PR DESCRIPTION
## 이슈
- #76

## 어떤 이유로 MR를 하셨나요?
- 테스트 수정

## 작업 사항
- 인메모리 H2 DB를 사용해 테스트 하도록 수정
  - 실제 DB에 연결하지 않으므로 독립적인 테스트케이스 사용 가능.
    - @choihojo 3867324 커밋 관련해서 로컬 개발 시 사용하던 MariaDB 서버를 끄고 설정해둔 H2를 사용해 테스트가 성공하는 것을 확인했습니다.
- 의존성, 설정파일 추가
- 전화번호 정규식 수정

## 참고 사항
- `@DataJpaTest`: In-memory DB인 H2로 테스트용 DB를 자동 생성, `@Transactional` 기능을 포함해 테스트 후 자동 롤백 지원.
  - <https://mangkyu.tistory.com/145>
  - `application-test.yml` 설정 방법: <https://0soo.tistory.com/40>
- Mapstruct Mapper `@Autowired` 불가 문제: <https://stackoverflow.com/questions/50913390/cannot-inject-mapstruct-mapper-into-spring-boot-junit-test>
