### PR TITLE
[FE] feat: 소비자 마이페이지 "내가 찜한 캠핑장" UI 구현 

### DIFF
--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -6,11 +6,19 @@ import storage from "redux-persist/lib/storage";
 import { authReducer } from "@/features/login/authSlice";
 import { campingMapReducer } from "@/features/search/campingMapSlice";
 import { selectedCompReducer } from "@/features/mypage/componentSlice";
+import { favoriteCampsReducer } from "@/features/mypage/myFavorite";
 
 const persistConfig = {
   key: "root",
   storage,
-  whitelist: ["ownerTab", "ownerSide", "auth", "campingMap", "selectedComp"],
+  whitelist: [
+    "ownerTab",
+    "ownerSide",
+    "auth",
+    "campingMap",
+    "selectedComp",
+    "favoriteCamps"
+  ],
 };
 
 const rootReducer = combineReducers({
@@ -19,6 +27,7 @@ const rootReducer = combineReducers({
   auth: authReducer,
   campingMap: campingMapReducer,
   selectedComp: selectedCompReducer,
+  favoriteCamps: favoriteCampsReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/frontend/src/components/my/consumer/MyFavoriteCamp.tsx
+++ b/frontend/src/components/my/consumer/MyFavoriteCamp.tsx
@@ -1,8 +1,63 @@
+import { useState } from 'react';
+import MyFavoriteCampItem from '@/components/my/consumer/MyFavoriteCampItem';
+import { myCampingDummyList } from '@/components/my/consumer/MyFavoriteDummy';
+
 const MyFavoriteCamp = (): JSX.Element => {
+  const initialCampsToShow = 4; // 초기에 보여줄 관심 캠핑장 카드 수
+  const [visibleCamps, setVisibleCamps] = useState(myCampingDummyList.slice(0, initialCampsToShow)); // 현재 화면에 보여줄 캠핑장 개수 상태 관리
+  const [allCamps, setAllCamps] = useState(myCampingDummyList); // 캠핑장 데이터 상태 관리
+
+  // "더보기" 버튼 클릭 핸들러
+  const handleShowMoreCamps = () => {
+    setVisibleCamps(prev => [...prev, ...myCampingDummyList.slice(prev.length, prev.length + 2)]);
+  };
+
+  // "줄이기" 버튼 클릭 핸들러
+  const handleShowLessCamps = () => {
+    setVisibleCamps(prev => prev.slice(0, Math.max(initialCampsToShow, prev.length - 2)));
+  };
+
+  // "좋아요 취소" 시 리스트에서 정보 제거
+  const removeCamp = (campId: number) => {
+    const updatedCamps = allCamps.filter(camp => camp.id !== campId);
+    setAllCamps(updatedCamps);
+    setVisibleCamps(updatedCamps.slice(0, Math.min(visibleCamps.length, updatedCamps.length))); // 화면에 표시되는 캠핑장 목록도 업데이트
+  };
 
   return (
     <div>
-      내가 찜한 캠핑장
+      {/* 관심 캠핑장 헤더 */}
+      <div className='flex flex-col pb-4'>
+        <h1 className='text-lg font-bold'>내가 찜한 캠핑장</h1>
+        <h1 className="text-sm text-gray-400">"유저 닉네임"님이 좋아요한 캠핑장입니다.</h1>
+      </div>
+
+      {/* 관심 캠핑장 카드 */}
+      <div className='max-h-[550px] overflow-y-auto'>
+        <div className='grid grid-cols-2 gap-4 px-2 pb-2'>
+          {visibleCamps.map(camp => (
+            <MyFavoriteCampItem 
+              key={camp.id}
+              camp={camp}
+              onRemove={removeCamp} // 캠프 제거 함수 전달
+            />
+          ))}
+        </div>
+
+        {/* 더보기, 줄이기 버튼 */}
+        <div className='flex justify-center pt-6'>
+          <div className='px-2'>
+            {visibleCamps.length < allCamps.length && (
+              <button onClick={handleShowMoreCamps}>더보기</button>
+            )}
+          </div>
+          <div className='px-2'>
+            {visibleCamps.length > initialCampsToShow && (
+              <button onClick={handleShowLessCamps}>줄이기</button> 
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/my/consumer/MyFavoriteCampItem.tsx
+++ b/frontend/src/components/my/consumer/MyFavoriteCampItem.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+// import { useDispatch, useSelector } from 'react-redux';
+// import { RootState } from '@/app/store';
+// import { toggleLike } from '@/features/mypage/myFavorite';
+import { FaStar, FaHeart } from "react-icons/fa6";
+import { IMyFavoritCampProps } from '@/types/myFavorite'
+import Modal from '@/components/@common/Modal/Modal';
+
+interface MyFavoriteCampItemProps {
+  camp: IMyFavoritCampProps;
+  onRemove: (campId: number) => void;
+}
+
+const MyFavoriteCampItem = ({
+  camp,
+  onRemove
+}:MyFavoriteCampItemProps) => {
+  // const dispatch = useDispatch();
+  // @TODO: 리덕스 스토어로 "좋아요" 상태 전역관리 -> 백엔드와의 연결을 통해 필요하다면 사용
+  // const isLiked = useSelector((state: RootState) => state.favoriteCamps.likedCamps[camp.id]);
+
+  // 좋아요 상태 관리, 처음에는 항상 좋아요 상태(true)
+  const [isLiked, setIsLiked] = useState<boolean>(true);
+  const [showConfirmModal, setShowConfirmModal] = useState(false); // 좋아요 취소 확인 모달 상태 관리
+
+  const handleToggleLike = () => {
+    if (isLiked) {
+      setShowConfirmModal(true);  // 좋아요 상태일 때 모달 표시
+    } else {
+      setIsLiked(!isLiked);  // 좋아요 상태가 아니면 바로 토글
+    }
+  };
+
+  const confirmUnLike = () => {
+    setIsLiked(false);  // 좋아요 상태를 비활성화로 변경
+    onRemove(camp.id); // 관심 캠핑장에서 제거한다.
+    setShowConfirmModal(false); // 모달은 닫아준다.
+    // @TODO : 추후에 백엔드와의 통신을 통해 좋아요 취소했다는 정보를 다시 알려줘야함
+  };
+
+  return (
+    <div className="flex justify-center">
+      <div key={camp.id} className="relative px-2 py-2 w-full shadow-lg rounded-xl">
+        <img
+          src={camp.image}
+          alt={camp.name}
+          className="w-full h-[150px] rounded-md object-cover object-center"
+        />
+        <button
+          onClick={handleToggleLike}
+          className={`absolute top-5 right-5 ${isLiked ? 'text-red-500' : 'text-gray-300'}`}
+          aria-label="좋아요 토글"
+        >
+          <FaHeart size={20} />
+        </button>
+        {/* 좋아요 취소 시 모달 호출 */}
+        {showConfirmModal && (
+          <Modal
+            width="w-1/3"
+            title={camp.name}
+            hasIcon={false}
+            onClose={() => setShowConfirmModal(false)}
+          >
+            <div className="text-center p-1">
+              <p>이 캠핑장에 대한 관심을 <span className='text-red-400'>취소</span>하시겠어요?</p>
+              <div className="mt-4 flex justify-around">
+                <button
+                  className="hover:bg-SUB_GREEN_01 hover:text-MAIN_GREEN px-4 py-2 rounded-lg outline-none"
+                  onClick={confirmUnLike}
+                >
+                  <span>취소합니다</span>
+                </button>
+                <button
+                  className=" hover:bg-SUB_GREEN_01 hover:text-MAIN_GREEN px-4 py-2 rounded-lg outline-none"
+                  onClick={() => setShowConfirmModal(false)}
+                >
+                  <span>아니오</span>
+                </button>
+              </div>
+            </div>
+          </Modal>
+        )}
+
+        <div className="w-full pt-2 px-1">
+          {/* 캠핑장 이름 + 별점 */}
+          <div className="w-full flex justify-between">
+            <h1 className="font-bold">{camp.name}</h1>
+            <div className="flex items-center">
+              <FaStar className="text-yellow-500 mx-1" />
+              <p>{camp.rating}</p>
+            </div>
+          </div>
+          {/* 소개+주소 /// 가격 */}
+          <div className="w-full flex justify-between">
+            <div className="w-[50%]">
+              <p className="text-sm overflow-hidden whitespace-nowrap overflow-ellipsis">
+                {camp.description}
+              </p>
+              <p className="text-sm text-gray-400">{camp.location}</p>
+            </div>
+            <div className="w-[50%] flex justify-end">
+              <p className="text-xl text-orange-700 font-extrabold">
+                {camp.price} ~
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyFavoriteCampItem;

--- a/frontend/src/components/my/consumer/MyFavoriteDummy.tsx
+++ b/frontend/src/components/my/consumer/MyFavoriteDummy.tsx
@@ -1,0 +1,89 @@
+import photo1 from "@/assets/images/dummyCamping.png";
+import photo2 from "@/assets/images/dummy/camping_spot_2.png";
+import photo3 from "@/assets/images/dummy/camping_spot_3.png";
+import photo4 from "@/assets/images/dummy/camping_spot_4.jpg";
+
+// 더미데이터
+export const myCampingDummyList = [
+  {
+    id: 1,
+    name: "주용용캠핑장",
+    image: photo4,
+    rating: 4.5,
+    price: "50,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "경상북도 구미시",
+  },
+  {
+    id: 2,
+    name: "챔챔경캠핑장",
+    image: photo2,
+    rating: 4.8,
+    price: "40,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "경상북도 김천시",
+  },
+  {
+    id: 3,
+    name: "단비비캠핑장",
+    image: photo3,
+    rating: 3.8,
+    price: "60,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "경상북도 싸피시",
+  },
+  {
+    id: 4,
+    name: "커커현캠핑장",
+    image: photo4,
+    rating: 3.8,
+    price: "120,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "전라북도 싸피시",
+  },
+  {
+    id: 5,
+    name: "호호조캠핑장",
+    image: photo1,
+    rating: 4.0,
+    price: "100,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "경상남도 창원시",
+  },
+  {
+    id: 6,
+    name: "준준호캠핑장",
+    image: photo2,
+    rating: 4.1,
+    price: "85,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "부산광역시",
+  },
+  {
+    id: 7,
+    name: "귀찮아캠핑장",
+    image: photo3,
+    rating: 4.1,
+    price: "85,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "부산광역시",
+  },
+  {
+    id: 8,
+    name: "집갈래캠핑장",
+    image: photo4,
+    rating: 4.1,
+    price: "85,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "부산광역시",
+  },
+  {
+    id: 9,
+    name: "마지막캠핑장",
+    image: photo4,
+    rating: 4.1,
+    price: "85,000",
+    description: "깔끔하고 분위기 좋은 신상 캠핑 숙소",
+    location: "부산광역시",
+  },
+];

--- a/frontend/src/components/my/consumer/MyReview.tsx
+++ b/frontend/src/components/my/consumer/MyReview.tsx
@@ -74,7 +74,7 @@ const MyReview = ({
             <div className='w-[50%] pr-3'>
               <div className='flex flex-col items-end justify-center'>             
               <button className='flex justify-end'>
-                <p className='text-xs'>삭 제</p>
+                <p className='text-xs pr-1'>삭 제</p>
               </button>
                 {review.images.map((image, idx) => (
                   <img

--- a/frontend/src/features/mypage/myFavorite.ts
+++ b/frontend/src/features/mypage/myFavorite.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { myCampingDummyList } from '@/components/my/consumer/MyFavoriteDummy';
+
+interface FavoriteCampsState {
+  likedCamps: { [key: number]: boolean };
+}
+
+const initialState: FavoriteCampsState = {
+  // @TODO : 추후 백엔드로부터 좋아요 정보 리스트를 받아온 후 연결 로직 수정해야함
+  likedCamps: myCampingDummyList.reduce((acc, camp) => {
+    acc[camp.id] = true; // 모든 캠핑장을 초기에 좋아요 상태로 설정
+    return acc;
+  }, {} as { [key: number]: boolean }),
+};
+
+const favoriteCampsSlice = createSlice({
+  name: 'favoriteCamps',
+  initialState,
+  reducers: {
+    toggleLike: (state, action: PayloadAction<number>) => {
+      const campId = action.payload;
+      // console.log(`하트 누름: ${campId}`);
+      state.likedCamps[campId] = !state.likedCamps[campId];
+      // console.log(`새 상태 확인:`, state.likedCamps);
+    },
+  },
+});
+
+export const { toggleLike } = favoriteCampsSlice.actions;
+export const favoriteCampsReducer = favoriteCampsSlice.reducer;

--- a/frontend/src/types/myFavorite.ts
+++ b/frontend/src/types/myFavorite.ts
@@ -1,0 +1,9 @@
+export interface IMyFavoritCampProps {
+  id: number;
+  name: string;
+  image: string;
+  rating: number;
+  price: string;
+  description: string;
+  location: string;
+}


### PR DESCRIPTION
<!-- Please check the one that applies to this PR using "x". -->

## 이슈
- #97 

## 어떤 이유로 MR를 하셨나요?
- feature 병합

<!-- 
 필요없는거 지우기
feat : 새로운 기능을 추가
fix : 버그 수정 또는 기능에 대한 큰 변화와 결과에 변화가 있을 때
docs : 문서 관련 커밋
refactor : 기능에 대한 변화 없이 리팩토링
style : 코드 스타일 변경(formatting, missing semi colons, …)
test : 테스트 관련 커밋
chore : 기타 커밋
-->

## 작업 사항

- 사용자가 마이페이지에서 "내가 찜한 캠핑장"을 확인할 수 있도록 함.
- 추가로 사용자가 직접 "좋아요"를 다시 취소할 수 있는 기능까지 구현함.

## 참고 사항

![image](https://github.com/d106-campu/campu/assets/139833245/8d82e250-b582-48dd-8e01-171d885ae9a4)

- 좋아요 취소를 누를 경우, 한번 더 확인 절차를 거치는 모달까지 나오도록 함.