### PR TITLE
[BE] fix #130: 방 목록 조회 시 캠핑장 정보 제외

### DIFF
--- a/backend/src/main/java/com/d106/campu/room/dto/RoomDto.java
+++ b/backend/src/main/java/com/d106/campu/room/dto/RoomDto.java
@@ -1,6 +1,5 @@
 package com.d106.campu.room.dto;
 
-import com.d106.campu.campsite.dto.CampsiteDto;
 import lombok.Data;
 
 public class RoomDto {
@@ -9,7 +8,6 @@ public class RoomDto {
     public static class ListResponse {
 
         private Long id;
-        private CampsiteDto.IdAndName campsite;
         private String induty;
         private String name;
         private int baseNo;


### PR DESCRIPTION
## 이슈
- #130 

## 어떤 이유로 MR를 하셨나요?
- 코드 개선

## 작업 사항
- 특정 캠핑장의 방 목록을 조회하는 서비스 로직이므로 캠핑장 정보는 이미 알고 있는 상태. 정보가 중복됨.

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.