### PR TITLE
[FE] feat: KakaoMap Modal 컴포넌트 구현

### DIFF
--- a/frontend/src/components/@common/Map/KakaoMap.tsx
+++ b/frontend/src/components/@common/Map/KakaoMap.tsx
@@ -38,7 +38,7 @@ const KakaoMap = ({ locations }: { locations: LocationsList }) => {
 
     const options = {
       center: new window.kakao.maps.LatLng(locations[0].lat, locations[0].lng),
-      level: 9,
+      level: locations[0].level || 5,
     };
 
     const map = new window.kakao.maps.Map(container, options);

--- a/frontend/src/components/@common/Map/MapModal.tsx
+++ b/frontend/src/components/@common/Map/MapModal.tsx
@@ -2,18 +2,19 @@ import { useState } from "react";
 import Modal from "../Modal/Modal";
 import KakaoMap from "./KakaoMap";
 
-// interface IMapModalProps {
-//   lat: number;
-//   lng: number;
-// }
+interface IMapModalProps {
+  lat: number;
+  lng: number;
+}
 
-const MapModal = () => {
+const MapModal = ({ lat, lng }: IMapModalProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const toggleModal = () => {
     setIsOpen(!isOpen);
   };
 
-  const locations = [{ lat: 36.1071305028147, lng: 128.4169500162442 }];
+  // level: 지도 확대 정도 ( 기본 5로 임의 지정 )
+  const locations = [{ lat: lat, lng: lng, level: 5 }];
 
   return (
     <>

--- a/frontend/src/pages/home/index.tsx
+++ b/frontend/src/pages/home/index.tsx
@@ -1,29 +1,13 @@
 import Footer from "@/components/@common/Footer/Footer";
 import Header from "@/components/@common/Header/Header";
-import MapModal from "@/components/@common/Map/MapModal";
 import HomeContainer from "@/components/home/HomeContainer";
-import { useState } from "react";
 
 const HomePage = () => {
-  const [isMapModalOpen, setIsMapModalOpen] = useState(false);
-
-  const openMapModal = () => {
-    setIsMapModalOpen(true);
-  };
-
-  //임시
-  // const latitude = 37.5665;
-  // const longitude = 126.978;
-
   return (
     <div>
       <Header page={"main"} />
       <HomeContainer />
       <Footer />
-
-      {isMapModalOpen && <MapModal />}
-      {/* 모달을 열기 위한 버튼 또는 다른 UI를 추가합니다 */}
-      <button onClick={openMapModal}>지도 열기</button>
     </div>
   );
 };

--- a/frontend/src/types/map.ts
+++ b/frontend/src/types/map.ts
@@ -10,4 +10,5 @@ export interface IMapProps {
   rate?: number;
   lat?: number | undefined;
   lng?: number | undefined;
+  level?: number;
 }


### PR DESCRIPTION
<!-- Please check the one that applies to this PR using "x". -->

## 이슈
- #168 

## 어떤 이유로 MR를 하셨나요?
- feature 병합

<!-- 
 필요없는거 지우기
feat : 새로운 기능을 추가
fix : 버그 수정 또는 기능에 대한 큰 변화와 결과에 변화가 있을 때
docs : 문서 관련 커밋
refactor : 기능에 대한 변화 없이 리팩토링
style : 코드 스타일 변경(formatting, missing semi colons, …)
test : 테스트 관련 커밋
chore : 기타 커밋
-->

## 작업 사항

- 캠핑장 상세페이지 지도 모달 컴포넌트 구현

## 참고 사항

- 기본 지도를 띄우는 컴포넌트 구현하였습니다.
- MapModal 컴포넌트를 불러올때 경도와 위도 값을 전달해주시면 됩니다.
 (  { lat, lng } props 확인해주세요 number 타입입니다 ! )
- 기본 level은 5 (지도 확대정도)로 설정해두었는데 커스텀 하셔도 상관없습니다.
- 기타 지도 외에 필요한 정보는 스타일 조정하시면 됩니다 !
- KakaoMap 지도를 감싸는 <div>박스의 width와 height 조정 시 [%] 값이 적용이 되지 않으므로 [px]로 조정 부탁드립니다.
 ( 기본 값은 높이 [400px]로 지정해두었습니다. )

![MapModal](https://github.com/d106-campu/campu/assets/139419164/27bd1f9a-521e-4795-9a8f-508e17663db5)


