### PR TITLE
[BE] refactor: 사장님 캠핑장 조회 기능 분리

### DIFF
--- a/backend/src/main/java/com/d106/campu/campsite/controller/CampsiteController.java
+++ b/backend/src/main/java/com/d106/campu/campsite/controller/CampsiteController.java
@@ -35,11 +35,9 @@ public class CampsiteController implements CampsiteControllerDoc {
         int headCnt,
         @RequestParam(required = false) String induty,
         @RequestParam(required = false) String theme,
-        @RequestParam(required = false) boolean owner,
         Pageable pageable
     ) {
-        return campsiteService.getCampsiteListResponse(doNm, sigunguNm, startDate, endDate, headCnt, induty, theme, owner,
-            pageable);
+        return campsiteService.getCampsiteListResponse(doNm, sigunguNm, startDate, endDate, headCnt, induty, theme, pageable);
     }
 
     @Override

--- a/backend/src/main/java/com/d106/campu/campsite/controller/doc/CampsiteControllerDoc.java
+++ b/backend/src/main/java/com/d106/campu/campsite/controller/doc/CampsiteControllerDoc.java
@@ -43,7 +43,6 @@ public interface CampsiteControllerDoc {
         int headCnt,
         @Pattern(regexp = RegExpression.induty, message = "induty should be among these: caravan, autocamping, camping, glamping") String induty,
         @Pattern(regexp = RegExpression.theme, message = "theme should be among these: summer, trail, activity, spring, autumn, winter, sunset, sunrise, watersports, fishing, airsports, skiing") String theme,
-        boolean owner,
         Pageable pageable
     );
 

--- a/backend/src/main/java/com/d106/campu/campsite/service/CampsiteService.java
+++ b/backend/src/main/java/com/d106/campu/campsite/service/CampsiteService.java
@@ -66,7 +66,6 @@ public class CampsiteService {
      * @param headCnt   To filter available room.
      * @param induty    For campsites that has specific industry type.
      * @param theme     For campsites that has specific theme.
-     * @param owner     For campsites that the current user manages.
      * @param pageable
      * @return List of campsite.
      * @throws NotFoundException     If not login status.
@@ -83,7 +82,6 @@ public class CampsiteService {
         int headCnt,
         String induty,
         String theme,
-        boolean owner,
         Pageable pageable
     ) {
         User user = getUserByAccount();
@@ -92,10 +90,7 @@ public class CampsiteService {
         String sigunguNmStr = (sigunguNm == null) ? null : sigunguNm.getName();
 
         Page<Campsite> responsePage = null;
-        if (owner) {
-            checkUserRoleOwner(user);
-            responsePage = campsiteRepository.findByUser(pageable, user);
-        } else if (induty == null && theme == null) {
+        if (induty == null && theme == null) {
             responsePage = campsiteRepository.findAll(pageable, doNmStr, sigunguNmStr);
         } else if (induty != null && !induty.isBlank()) {
             responsePage = campsiteRepository.findByIndutyListContaining(


### PR DESCRIPTION
## 이슈
- #163 

## 어떤 이유로 MR를 하셨나요?
- 기능 분리
- 기존에는 캠핑장 목록 조회 API에서 `owner=true` 파라미터를 받으면 유저가 사장님 권한을 가졌는지 확인하고 캠핑장 목록을 조회.
- 캠핑장 조회에 지역, 기간, 인원 등의 필수 검색 조건이 생기면서 이러한 조건이 필요 없는 사장님 캠핑장 조회 기능의 분리가 필요.
- `/api/campsite/owner`로 분리.

## 작업 사항
- 기능 분리

## 참고 사항
- @minnnnnk0 메인페이지에서 캠핑장 조회할 때는 영향 없을 것 같고, 사장님 페이지에서 분리된 API로 호출하면 됩니다.
