### PR TITLE
[FE] feat: 빈자리알림 조회 및 삭제 API 연결 완료

### DIFF
--- a/frontend/src/components/my/ConsumerContainer.tsx
+++ b/frontend/src/components/my/ConsumerContainer.tsx
@@ -5,7 +5,7 @@ import FreeAlert from '@/components/my/freeAlert/FreeAlert';
 import MyProfile from '@/components/my/profile/MyProfile';
 import GetReservations from '@/components/my/consumer/MyReservationItem'; // 예약내역 더미데이터
 import GetMyReviews from '@/components/my/consumer/MyReviewItem'; // 내가쓴리뷰 더미데이터
-import GetMyAlerts from '@/components/my/freeAlert/FreeAlertItem'; // 빈자리알림 더미데이터
+// import { GetMyAlerts } from '@/components/my/freeAlert/FreeAlertItem'; // 빈자리알림 더미데이터 확인 필요할 경우 주석 해제
 
 interface IConsumerContainerProps {
   selectedComponent: string;
@@ -14,8 +14,9 @@ interface IConsumerContainerProps {
 const ConsumerContainer = ({
   selectedComponent
 }: IConsumerContainerProps): JSX.Element => {
-  // 더미 데이터 로드 및 첫 번째 예약 데이터 사용
-  const reservations = GetReservations();
+  
+  const reservations = GetReservations(); // 내 예약내역 더미데이터
+  // const myAlerts = GetMyAlerts(); // 더미데이터 확인 필요할 경우 주석 해제
   const firstReservation = reservations[0];
 
   const renderComponent = () => {
@@ -27,7 +28,7 @@ const ConsumerContainer = ({
       case 'MyFavoriteCamp':
         return <MyFavoriteCamp />;
       case 'FreeAlert':
-        return <FreeAlert alerts={GetMyAlerts.alerts} totalMyAlerts={GetMyAlerts.totalMyAlerts}/>;
+        return <FreeAlert />;
       case 'MyProfile':
         return <MyProfile phoneVerified={false}/>;
       default:

--- a/frontend/src/components/my/freeAlert/FreeAlert.tsx
+++ b/frontend/src/components/my/freeAlert/FreeAlert.tsx
@@ -1,49 +1,105 @@
-import { useState } from "react";
-import { IMyFreeAlert } from "@/types/myFreeAlert";
+import { useState, useEffect } from "react";
+import { IEmptyNotification } from "@/types/myFreeAlert";
 import FreeAlertList from "@/components/my/freeAlert/FreeAlertList";
 import Modal from '@/components/@common/Modal/Modal';
+import { useSelector } from "react-redux";
+import { RootState } from '@/app/store';
+import { useMyAlerts } from '@/hooks/myAlerts/useMyAlerts';
 
-interface IFreeAlertProps {
-  alerts: IMyFreeAlert[];
-  totalMyAlerts: number;
-}
-
-const FreeAlert = ({
-  alerts,
-  totalMyAlerts,
-}: IFreeAlertProps): JSX.Element => {
-  const [visibleAlerts, setVisibleAlerts] = useState<IMyFreeAlert[]>(alerts.slice(0, 2)); // 2개씩 잘라서 보여줌
+const FreeAlert = (): JSX.Element => {
+  const { myAlertsQuery, deleteAlertMutation  } = useMyAlerts();
+  const nickname = useSelector((state: RootState) => state.auth.nickname); // 닉네임
+  const [visibleAlerts, setVisibleAlerts] = useState<IEmptyNotification[]>([]);
   const [viewCount, setIsViewCount] = useState<number>(2); // 처음 보여줄 빈자리 알림 개수 관리
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
-  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null);
+  const [selectedAlertId, setSelectedAlertId] = useState<number | null>(null); // 빈자리 알림 식별번호
+  const [selectedCampsiteId, setSelectedCampsiteId] = useState<number | null>(null); // campsiteId
+
+  // 데이터가 로드되었을 때 초기 목록 설정 (2개씩 잘라서 보여줌)
+  useEffect(() => {
+    if (myAlertsQuery.data) {
+      setVisibleAlerts(myAlertsQuery.data.data.emptyNotificationList.slice(0, viewCount));
+    }
+  }, [myAlertsQuery.data, viewCount]);
+
+  // "나의 빈자리알림" 목록 조회 API 요청 -> myAlertsQuery 호출하여 데이터 접근
+  // "??" 기준으로 좌측 피연산자가 null(undefined)일 경우 우측의 빈 배열을 반환하도록 설정
+  const emptyNotificationList = myAlertsQuery.data?.data.emptyNotificationList ?? [];
+
+  // 로딩 중일 때 처리
+  if (myAlertsQuery.isLoading) {
+    return <div>로딩 중... 잠시만 기다려주세요 😀</div>;
+  }
+
+  // 데이터 에러 발생 시 처리
+  if (myAlertsQuery.isError) {
+    return <div>빈자리 알림을 가져오지 못했습니다. 😭</div>;
+  }
+
+  // 빈자리 알림이 아직 하나도 없을 때 처리
+  if (!emptyNotificationList || emptyNotificationList.length === 0) {
+    console.error("빈자리알림 리스트가 비어있음 !");
+    return (
+      <>
+        <div>
+          <div className='flex flex-col pb-10'>
+            <h1 className='text-lg font-bold'>
+              빈자리 알림
+              <span className="text-MAIN_GREEN font-thin pl-1">0</span>
+            </h1>
+            <h1 className="text-sm text-gray-400">{nickname}님이 빈자리 알림은 설정한 캠핑장입니다.</h1>
+          </div>
+          <div className="text-center">
+            <h1 className="">빈자리 알림을 신청한 <span className="text-MAIN_GREEN">캠핑장</span>이 없어요 😃</h1>
+            <h1 className="text-sm text-GRAY pt-2">원하는 캠핑장 정보에 알림을 신청해보세요 !</h1>
+          </div>
+        </div>
+      </>
+    )
+  }
+
 
   // 빈자리 알림 취소 모달 관리
-  const handleCancelAlert = (alertName: string) => {
+  const handleCancelAlert = (alertName: number, campsiteId: number) => {
     setShowConfirmModal(true);
     setSelectedAlertId(alertName);
+    setSelectedCampsiteId(campsiteId); 
   };
 
   // 빈자리 알림 취소 확정 시 리스트에서 정보 제거 
   const confirmCancelAlert = () => {
-    if (selectedAlertId !== null) {
-      setVisibleAlerts(prev => prev.filter(alert => alert.campsiteName !== selectedAlertId));
-      setShowConfirmModal(false); // 모달 닫기
-      setSelectedAlertId(null); // AlertId는 다시 초기화
+    if (selectedCampsiteId !== null) {
+      // 빈자리 알림 DELETE 요청 API 연결
+      console.log("선택한 Id 확인 :", selectedCampsiteId)
+      deleteAlertMutation.mutate(selectedCampsiteId, {
+        onSuccess: () => {
+          // 성공적으로 삭제 처리 후 상태 업데이트
+          setVisibleAlerts(prev => prev.filter(alert => alert.room.campsite.campsiteId !== selectedCampsiteId));
+          console.log('빈자리알림 하나 삭제함!');
+          setShowConfirmModal(false); // 모달 닫기
+          setSelectedAlertId(null); // AlertId는 다시 초기화
+          setSelectedCampsiteId(null);
+          
+        },
+        onError: (error) => {
+          console.error('빈자리 알림 삭제 실패:', error);
+        }
+      });
     }
   };
 
   // 더보기
   const handleShowMoreAlerts = () => {
-    const newCount = Math.min(viewCount + 2, alerts.length);
+    const newCount = Math.min(viewCount + 2, emptyNotificationList.length);
     setIsViewCount(newCount);
-    setVisibleAlerts(alerts.slice(0, newCount));
+    setVisibleAlerts(emptyNotificationList.slice(0, newCount));
   };
 
   // 줄이기
   const handleShowLessAlerts = () => {
     const newCount = Math.max(viewCount - 2, 2);
     setIsViewCount(newCount);
-    setVisibleAlerts(alerts.slice(0, newCount));
+    setVisibleAlerts(emptyNotificationList.slice(0, newCount));
   };
 
   return (
@@ -52,20 +108,20 @@ const FreeAlert = ({
     <div className='flex flex-col pb-4'>
       <h1 className='text-lg font-bold'>
         빈자리 알림
-        <span className="text-MAIN_GREEN font-thin pl-1">{totalMyAlerts}</span>
+        <span className="text-MAIN_GREEN font-thin pl-1">{emptyNotificationList.length}</span>
       </h1>
-      <h1 className="text-sm text-gray-400">"유저 닉네임"님이 빈자리 알림은 설정한 캠핑장입니다.</h1>
+      <h1 className="text-sm text-gray-400">{nickname}님이 빈자리 알림은 설정한 캠핑장입니다.</h1>
     </div>
 
     <div className='max-h-[500px] overflow-y-auto relative'>
       {/* 빈자리 알림 설정한 더미데이터 리스트 */}
       <FreeAlertList
         alerts={visibleAlerts}
-        handleCancelAlert={handleCancelAlert}
+        handleCancelAlert={(alertId, campsiteId) => handleCancelAlert(alertId, campsiteId)}
         viewCount={viewCount}
         handleShowMoreAlerts={handleShowMoreAlerts}
         handleShowLessAlerts={handleShowLessAlerts}
-        totalMyAlerts={totalMyAlerts}
+        totalMyAlerts={emptyNotificationList.length}
       />
     </div>
 

--- a/frontend/src/components/my/freeAlert/FreeAlertItem.tsx
+++ b/frontend/src/components/my/freeAlert/FreeAlertItem.tsx
@@ -1,68 +1,28 @@
-import { IMyFreeAlertList } from '@/types/myFreeAlert';
+import { IEmptyNotificationList } from '@/types/myFreeAlert';
 import photo1 from "@/assets/images/dummy/camping_spot_2.png";
-import photo2 from "@/assets/images/dummy/camping_spot_3.png";
-import photo3 from "@/assets/images/dummy/camping_spot_4.jpg";
 
-// 더미데이터 5개
-const DummyAlerts: IMyFreeAlertList = {
-  totalMyAlerts: 6,
-  alerts: [
-    {
-      campsiteName: "캠프유캠핑 캠핑장",
-      address: "경상북도 칠곡군 가산면 금화리 산49-1 캠핑핑 캠핑장",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 3,
-      price: 150000,
-      images: [photo1]
-    },
-    {
-      campsiteName: "아귀찮아아 캠핑장",
-      address: "부산광역시 남구 신선로 294",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 2,
-      price: 115000,
-      images: [photo2]
-    },
-    {
-      campsiteName: "이름짓는거 캠핑장",
-      address: "경상북도 칠곡군 가산면 금화리 산49-1 캠핑핑 캠핑장",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 4,
-      price: 100000,
-      images: [photo3]
-    },
-    {
-      campsiteName: "생각이안나 캠핑장",
-      address: "경상북도 칠곡군 가산면 금화리 산49-1 캠핑핑 캠핑장",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 2,
-      price: 120000,
-      images: [photo1]
-    },
-    {
-      campsiteName: "크크크크킄 캠핑장",
-      address: "경상북도 칠곡군 가산면 금화리 산49-1 캠핑핑 캠핑장",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 1,
-      price: 85000,
-      images: [photo2]
-    },
-    {
-      campsiteName: "히히히히힣 캠핑장",
-      address: "경상북도 칠곡군 가산면 금화리 산49-1 캠핑핑 캠핑장",
-      area: "A구역(벚꽃 캠핑존) 10",
-      date: "24.05.10 (금) ~ 24.05.14 (화)",
-      people: 2,
-      price: 85000,
-      images: [photo2]
-    },
-    // 추가 리뷰 데이터...
-  ]
-};
-
-export default DummyAlerts;
+// 더미데이터 1개
+export function GetMyAlerts(): IEmptyNotificationList {
+  return {
+    result: "ok",
+    data: {
+      emptyNotificationList: [
+        {
+          emptyNotificationId: 1,
+          startDate: "2024-05-11",
+          endDate: "2024-05-12",
+          room: {
+            roomName: "A구역 (벚꽃 캠핑존)",
+            campsite: {
+              campsiteId: 1,
+              campsiteName: "캠프유캠푸 캠핑장",
+              address: "강원도 춘천시 남면 가옹개길 52-9",
+              thumbnailImageUrl: `${photo1}`
+            }
+          }
+        }
+        // 추가 데이터...
+      ]
+    }
+  };
+}

--- a/frontend/src/components/my/freeAlert/FreeAlertList.tsx
+++ b/frontend/src/components/my/freeAlert/FreeAlertList.tsx
@@ -1,9 +1,9 @@
 import { FaBell } from "react-icons/fa";
-import { IMyFreeAlert } from "@/types/myFreeAlert";
+import { IEmptyNotification } from "@/types/myFreeAlert";
 
 interface IFreeAlertListProps {
-  alerts: IMyFreeAlert[];
-  handleCancelAlert: (campsiteName: string) => void;
+  alerts: IEmptyNotification[];
+  handleCancelAlert: (alertId: number, campsiteId: number) => void;
   viewCount: number;
   handleShowMoreAlerts: () => void;
   handleShowLessAlerts: () => void;
@@ -21,50 +21,45 @@ const FreeAlertList = ({
   return (
     <div className='grid grid-cols-1 gap-4'>
       {alerts.map((alert, index) => (
-        <div key={index} className="w-full flex justify-center p-2 shadow-lg rounded-lg bg-white">
+        <div key={index} className="w-full flex justify-center p-2 pb-3 shadow-lg rounded-xl bg-white">
           <div className="w-[45%] px-1">
             <div className="flex flex-col">
-              <h2 className="text-lg">{alert.campsiteName}</h2>
+              <h2 className="text-lg">{alert.room.campsite.campsiteName}</h2>
               <img
-                src={alert.images[0]}
-                alt={alert.campsiteName}
+                src={alert.room.campsite.thumbnailImageUrl}
+                alt={alert.room.campsite.campsiteName}
                 className="w-[300px] h-[150px] object-cover object-center rounded-lg mt-2"
               />
             </div>
           </div>
 
-          <div className="w-[50%] text-sm">
-            <div className="flex justify-end">
-              <button
-                className="flex items-center bg-SUB_YELLOW hover:bg-yellow-200 rounded-lg px-2 py-1"
-                onClick={() => handleCancelAlert(alert.campsiteName)}
-              >
-                <FaBell className="text-yellow-500"/>
-                <span className="text-gray-600 hover:text-MAIN_GREEN pl-2">빈자리 알림 취소</span>
-              </button>
-            </div>
+          <div className="w-[50%] text-sm pt-8">
             <div className="py-1">
               <h1 className="text-GRAY">캠핑장 위치</h1>
-              <p>{alert.address}</p>
+              <p className="font-bold">{alert.room.campsite.address}</p>
             </div>
             <div className="flex justify-between items-center py-2">
               <div>
                 <h1 className="text-GRAY">날짜</h1>
-                <p>{alert.date}</p>
-              </div>
-              <div className="px-2">
-                <h1 className="text-GRAY">인원</h1>
-                <p>{alert.people}명</p>
+                {/* 입실일 ~ 퇴실일 */}
+                <p>
+                  <span className="text-MAIN_GREEN">{alert.startDate}</span> ~ <span className="text-red-500">{alert.endDate}</span>
+                </p>
               </div>
             </div>
-            <div className="flex justify-between items-start py-2">
+            <div className="flex justify-between items-center py-2">
               <div>
                 <h1 className="text-GRAY">사이트</h1>
-                <p>{alert.area}</p>
+                <p className="text-MAIN_GREEN font-bold">{alert.room.roomName}</p>
               </div>
-              <div className="px-2">
-                <h1 className="text-GRAY">가격</h1>
-                <p className="text-lg text-red-500">{alert.price.toLocaleString()}원</p>
+              <div>
+                <button
+                  className="flex items-center bg-SUB_YELLOW hover:bg-yellow-200 rounded-lg px-2 py-1"
+                  onClick={() => handleCancelAlert(alert.emptyNotificationId, alert.room.campsite.campsiteId)}
+                >
+                  <FaBell className="text-yellow-500"/>
+                  <span className="text-gray-600 hover:text-MAIN_GREEN pl-2">빈자리 알림 취소</span>
+                </button>
               </div>
             </div>
           </div>

--- a/frontend/src/hooks/myAlerts/useMyAlerts.ts
+++ b/frontend/src/hooks/myAlerts/useMyAlerts.ts
@@ -1,0 +1,30 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { IEmptyNotificationList } from '@/types/myFreeAlert';
+import { fetchMyAlerts, deleteMyAlert  } from '@/services/myAlerts/api';
+
+export const useMyAlerts = () => {
+
+  // 내 빈자리 알림 조회
+  const myAlertsQuery = useQuery<IEmptyNotificationList>({
+    queryKey: ['myAlerts'],
+    queryFn: fetchMyAlerts,
+  });
+
+  // 내 빈자리 알림 삭제
+  const deleteAlertMutation = useMutation({
+    mutationKey: ['deleteAlert'],
+    mutationFn: deleteMyAlert,
+    onSuccess: () => {
+      // 삭제한 후에 남아있는 리스트 댜시 불러오게 함
+      myAlertsQuery.refetch();
+    },
+    onError: (error) => {
+      console.error('삭제못했음 :', error);
+    }
+  });
+
+  return {
+    myAlertsQuery,
+    deleteAlertMutation
+  };
+};

--- a/frontend/src/services/myAlerts/api.ts
+++ b/frontend/src/services/myAlerts/api.ts
@@ -1,0 +1,15 @@
+import { IEmptyNotificationList } from '@/types/myFreeAlert';
+// import { APIResponse } from "@/types/model";
+import { axiosAuthInstance } from '@/apis/axiosInstance';
+
+// 빈자리 알림 조회 API 요청
+export const fetchMyAlerts = async (): Promise<IEmptyNotificationList> => {
+  const response = await axiosAuthInstance.get('/mypage/empty-notification');
+  return response.data;
+}
+
+// 빈자리 알림 삭제 API 요청
+export const deleteMyAlert = async (roomId: number): Promise<{ result: string }> => {
+  const response = await axiosAuthInstance.delete(`/empty-notification/${roomId}`);
+  return response.data;
+}

--- a/frontend/src/services/user/api.ts
+++ b/frontend/src/services/user/api.ts
@@ -14,7 +14,6 @@ export const updateUserNickName = async (data: IUserNickNameUpdate): Promise<API
   return response.data;
 };
 
-
 // 비밀번호 수정 요청
 export const updateUserPassword = async (data: IUserPasswordUpdate): Promise<APIResponse<{ result: string }>> => {
   const response = await axiosAuthInstance.post('/mypage/profile/password', data);

--- a/frontend/src/types/myFreeAlert.ts
+++ b/frontend/src/types/myFreeAlert.ts
@@ -1,14 +1,29 @@
-export interface IMyFreeAlert {
+// 캠핑장 정보 (식별번호, 이름, 주소, 사진URL)
+export interface ICampsite {
+  campsiteId: number;
   campsiteName: string;
   address: string;
-  date: string;
-  people: number;
-  area: string;
-  price: number;
-  images: string[];
+  thumbnailImageUrl: string;
 }
 
-export interface IMyFreeAlertList {
-  totalMyAlerts: number;
-  alerts: IMyFreeAlert[];
+// 캠핑장 정보 내에 방 정보 (방 이름)
+export interface IRoom {
+  roomName: string;
+  campsite: ICampsite;
+}
+
+// 빈자리 알림 식별 (식별번호, 입실일, 퇴실일)
+export interface IEmptyNotification {
+  emptyNotificationId: number;
+  startDate: string;
+  endDate: string;
+  room: IRoom;
+}
+
+// 빈자리알림 리스트 (결과값과 그 데이터)
+export interface IEmptyNotificationList {
+  result: string;
+  data: {
+    emptyNotificationList: IEmptyNotification[];
+  }
 }


### PR DESCRIPTION
<!-- Please check the one that applies to this PR using "x". -->

## 이슈
- #231 

## 어떤 이유로 MR를 하셨나요?
- feature 병합

<!-- 
 필요없는거 지우기
feat : 새로운 기능을 추가
fix : 버그 수정 또는 기능에 대한 큰 변화와 결과에 변화가 있을 때
docs : 문서 관련 커밋
refactor : 기능에 대한 변화 없이 리팩토링
style : 코드 스타일 변경(formatting, missing semi colons, …)
test : 테스트 관련 커밋
chore : 기타 커밋
-->

## 작업 사항

- 마이페이지에서 내가 신청한 빈자리 알림 리스트를 조회할 수 있음
- 사용자가 원할 때, 빈자리알림 취소 모달을 통해 리스트에서 빈자리알림을 제거할 수 있음

## 참고 사항

![빈자리알림 없을 때](https://github.com/d106-campu/campu/assets/139833245/caf5fa85-da85-4511-919f-0834f40e16ad)

- 빈자리 알림을 하나도 신청하지 않은 초기 상태일 때입니다.

![빈자리알림 불러옴](https://github.com/d106-campu/campu/assets/139833245/ed99cdcd-466f-48a7-8a69-0dbd4c52448c)

- 신청한 빈자리알림에 대해 불러오고 언제든 취소가 가능하도록 했습니다.