### PR TITLE
[FE] fix: 캠핑장 좋아요 버튼 에러 수정

### DIFF
--- a/frontend/src/app/sagas/campsiteLikesSaga.ts
+++ b/frontend/src/app/sagas/campsiteLikesSaga.ts
@@ -1,6 +1,8 @@
 import { call, put, takeLeading } from "redux-saga/effects";
 import {
-  toggleLikeRequest, addLike, removeLike, setLikes, setLoading
+  addLike,
+  removeLike,
+  setLoading,
 } from "@/features/like/campsiteLikeSlice";
 import { APIResponse } from "@/types/model";
 import { postLikes } from "@/services/reservation/api";

--- a/frontend/src/components/@common/Like/LikeButton.tsx
+++ b/frontend/src/components/@common/Like/LikeButton.tsx
@@ -2,27 +2,37 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/app/store";
 import { toggleLikeRequest } from "@/features/like/campsiteLikeSlice";
 import { VscHeart, VscHeartFilled } from "react-icons/vsc";
+import { useEffect, useState } from "react";
+import Toast from "@/components/@common/Toast/Toast";
 
 interface ILikeButtonProps {
+  like: boolean; // 초기 좋아요 상태
   campsiteId: number;
   className?: string;
   iconSize?: number;
 }
 
 const LikeButton = ({
+  like,
   campsiteId,
   className,
   iconSize = 38,
 }: ILikeButtonProps) => {
   const isLogin = useSelector((state: RootState) => state.auth.isLogin);
-  const isLiked = useSelector(
-    (state: RootState) => state.campsiteLike.likes[campsiteId] !== undefined
-  );
+  const [isLiked, setIsLiked] = useState(like); // 초기 상태를 prop에서 받음
   const dispatch = useDispatch();
+
+  // 로그인 상태가 변경되었을 때 좋아요 상태를 리셋할 수도 있음
+  useEffect(() => {
+    setIsLiked(like);
+  }, [like]);
 
   const handleToggleLike = () => {
     if (isLogin) {
       dispatch(toggleLikeRequest(campsiteId)); // 좋아요 버튼 클릭 시 액션 디스패치
+      setIsLiked(!isLiked); // 로컬 상태 토글
+    } else {
+      Toast.error("좋아요를 누르려면 로그인이 필요합니다.");
     }
     return;
   };

--- a/frontend/src/components/home/myCamping/MyCampingItem.tsx
+++ b/frontend/src/components/home/myCamping/MyCampingItem.tsx
@@ -11,7 +11,7 @@ const MyCampingItem = ({ camping }: { camping: IMyFavoritCampRes }) => {
         className="w-full rounded-md h-32 object-cover object-center"
       />
       <div className="absolute top-7 right-4">
-        <LikeButton campsiteId={camping.campsiteId} iconSize={25} />
+        <LikeButton like={true} campsiteId={camping.campsiteId} iconSize={25} />
       </div>
       <div className="p-2">
         <div className="flex justify-between">

--- a/frontend/src/components/home/recommend/RecommendItem.tsx
+++ b/frontend/src/components/home/recommend/RecommendItem.tsx
@@ -12,7 +12,7 @@ const RecommendItem = ({ item }: { item: ICampsiteSimpleRes }) => {
           className="w-full rounded-md h-40 object-cover object-center"
         />
         <div className="absolute top-7 right-4">
-          <LikeButton campsiteId={item.id} iconSize={25} />
+          <LikeButton like={item.like} campsiteId={item.id} iconSize={25} />
         </div>
         <div className="p-2">
           <div className="flex justify-between">

--- a/frontend/src/components/reservation/CampSiteIntro.tsx
+++ b/frontend/src/components/reservation/CampSiteIntro.tsx
@@ -65,7 +65,7 @@ const CampSiteIntro = ({ data }: { data: ICampSiteIntro }) => {
         <div className="flex justify-between items-end">
           <h1 className="font-bold text-3xl">{data.campsite_faclt_nm}</h1>
           {/* 좋아요 */}
-          <LikeButton campsiteId={data.id} />
+          <LikeButton like={data.isLiked} campsiteId={data.id} />
         </div>
 
         {/* 캠핑장 필수 정보 */}

--- a/frontend/src/components/search/searchSection/SearchCampingItem.tsx
+++ b/frontend/src/components/search/searchSection/SearchCampingItem.tsx
@@ -47,7 +47,11 @@ const SearchCampingItem = ({ camping }: { camping: ICampsiteSimpleRes }) => {
             </div>
           </div>
           <div className="pr-4">
-            <LikeButton campsiteId={camping.id} iconSize={20} />
+            <LikeButton
+              like={camping.like}
+              campsiteId={camping.id}
+              iconSize={20}
+            />
           </div>
         </div>
         <div>

--- a/frontend/src/features/like/campsiteLikeSlice.ts
+++ b/frontend/src/features/like/campsiteLikeSlice.ts
@@ -14,8 +14,8 @@ const campsiteLikeSlice = createSlice({
   name: "campsiteLike",
   initialState,
   reducers: {
-    toggleLikeRequest(state, action: PayloadAction<number>) {
-      // 좋아요 토글 요청, 사가에서 처리
+    toggleLikeRequest(_, __: PayloadAction<number>) {
+      // 좋아요 토글 요청, 사가에서 처리됨
     },
     addLike(state, action: PayloadAction<number>) {
       const campsiteId = action.payload;
@@ -33,5 +33,6 @@ const campsiteLikeSlice = createSlice({
   },
 });
 
-export const { toggleLikeRequest, addLike, removeLike, setLikes, setLoading } = campsiteLikeSlice.actions;
+export const { toggleLikeRequest, addLike, removeLike, setLikes, setLoading } =
+  campsiteLikeSlice.actions;
 export const campsiteLikeReducer = campsiteLikeSlice.reducer;

--- a/frontend/src/services/reservation/api.ts
+++ b/frontend/src/services/reservation/api.ts
@@ -6,9 +6,7 @@ import { ILikeRes, IRoomListRes } from "@/types/reservation";
 export const postLikes = async (
   campsiteId: number
 ): Promise<APIResponse<ILikeRes>> => {
-  console.log(`Sending like request for campsite ID: ${campsiteId}`); // 요청 로깅
   const res = await axiosAuthInstance.post(`/campsite/like/${campsiteId}`);
-  console.log(res); // 응답 로깅
   return res.data;
 };
 


### PR DESCRIPTION
<!-- Please check the one that applies to this PR using "x". -->

## 이슈
- #261

## 어떤 이유로 MR를 하셨나요?
- feature 병합

<!-- 
 필요없는거 지우기
feat : 새로운 기능을 추가
fix : 버그 수정 또는 기능에 대한 큰 변화와 결과에 변화가 있을 때
docs : 문서 관련 커밋
refactor : 기능에 대한 변화 없이 리팩토링
style : 코드 스타일 변경(formatting, missing semi colons, …)
test : 테스트 관련 커밋
chore : 기타 커밋
-->

## 작업 사항
- 좋아요 상태 관리 수정
- LikeButton 컴포넌트에 like props 추가
- 로그인 안 하고 좋아요 버튼 클릭 시 토스트 메시지 추가 

## 참고 사항
-  아직 캠핑장 상세 조회나 메인 홈의 API 통신이 완벽하게 끝나지 않아, 정확한 테스트를 하지 못했어요 😥
 swagger을 통해 like의 값이 토글되는 것은 확인했으나 문제가 생길 시 바로 알려주시면 감사하겠습니다!

- LikeButton 컴포넌트에 like props 추가 후 LikeButton 컴포넌트가 사용된 곳에 임의로 props를 추가해 놓았습니다!
확인 부탁드려요 😊 @minnnnnk0  @Agwii 

- 추후 병합 시 충돌이 날 수도 있을 것 같아요 😥😥😥

- MyCampingItem 컴포넌트의 경우, API 명세서와 swagger 확인 시 따로 like를 주지 않는 것 같아서 
일단은 아래 코드와 같이 like={true}로 지정해두었습니다
`<LikeButton like={true} campsiteId={camping.campsiteId} iconSize={25} />`

- ※ 로그아웃 시 저장된 상태를 초기화 해야 할 것 같습니다! @Agwii
현재는 Redux-Persist 사용으로 로그아웃 후에도 좋아요 버튼의 상태가 계속 유지되는 문제가 발생하고 있어요