### PR TITLE
[FE] fix: 유저 role 상태 관리 추가 및 401 에러에 대한 No Token 메세지 감지 처리

### DIFF
--- a/frontend/src/apis/axiosInstance.ts
+++ b/frontend/src/apis/axiosInstance.ts
@@ -47,7 +47,7 @@ axiosAuthInstance.interceptors.request.use(setAuthorization, (error) =>
 axiosFileInstance.interceptors.response.use(null, refresh);
 axiosAuthInstance.interceptors.response.use(
   (response) => response,
-  refresh // 토큰 만료의 경우 401 인증 실패를 처리하기 위해 refresh.ts에서 처리
+  (error) => refresh(error)
 );
 
 export { axiosCommonInstance, axiosAuthInstance, axiosFileInstance };

--- a/frontend/src/apis/refresh.ts
+++ b/frontend/src/apis/refresh.ts
@@ -1,10 +1,19 @@
 import { AxiosError } from 'axios';
 
-const refresh = async (error: AxiosError) => {
+interface ErrorResponse {
+  result?: string;
+  code?: string;
+  message?: string;
+}
 
-  if (error.response?.status === 401) {
+const refresh = async (error: AxiosError) => {
+  const errorMessage = (error.response?.data as ErrorResponse)?.message;
+  console.log("Axios 에러메세지 확인 :", error.response)
+
+  if (errorMessage === "No Token") {
     localStorage.setItem('accessToken', '');
     window.location.href = '/login';
+    console.log("토큰 만료")
   }
 
   return Promise.reject(error);

--- a/frontend/src/components/alert/AlertLink .tsx
+++ b/frontend/src/components/alert/AlertLink .tsx
@@ -26,7 +26,7 @@ const AlertLink = ({ page }: { page?: string }) => {
     setOpenAlert(!openAlert);
   };
 
-  console.log(newNotifyCnt);
+  // console.log(newNotifyCnt);
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (ref.current && !ref.current.contains(event.target as Node)) {

--- a/frontend/src/features/login/authSlice.ts
+++ b/frontend/src/features/login/authSlice.ts
@@ -3,11 +3,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 interface IUserLoginState {
   isLogin: boolean;
   nickname: string;
+  role: string;
 }
 
 const initialState: IUserLoginState = {
   isLogin : false,
-  nickname: "닉네임이 없습니다."
+  nickname: "닉네임이 없습니다.",
+  role: "USER"
 };
 
 const authSlice = createSlice({
@@ -20,8 +22,11 @@ const authSlice = createSlice({
     setNickname: (state, action: PayloadAction<string>) => {
       state.nickname = action.payload;
     },
+    setRole: (state, action: PayloadAction<string>) => {
+      state.role = action.payload;
+    }
   },
 });
 
-export const { setIsLogin, setNickname } = authSlice.actions;
+export const { setIsLogin, setNickname, setRole } = authSlice.actions;
 export const authReducer  = authSlice.reducer;

--- a/frontend/src/hooks/auth/useSignup.ts
+++ b/frontend/src/hooks/auth/useSignup.ts
@@ -10,10 +10,13 @@ import {
 } from '@/services/auth/api';
 import { ISignUpReq, IVerifyPhoneReq } from '@/types/auth';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setRole } from '@/features/login/authSlice';
 
 export const useSignup = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const dispatch = useDispatch();
 
   // 아이디 중복 검사
   const checkId = (account: string) => useQuery({
@@ -63,7 +66,11 @@ export const useSignup = () => {
   const loginMutation = useMutation({
     mutationFn: login,
     onSuccess: (res) => {
-      console.log("로그인 성공!! :", res)
+      console.log("로그인 성공!!")
+      
+      dispatch(setRole(res.data.user.role)) // 유저 권한
+      console.log("유저 권한 확인:", res.data.user.role)
+
       const from = location.state?.from?.pathname || '/';
       console.log('이전 페이지 확인 :', from)
       // 이전 페이지로 이동 (저장된 이전페이지 경로가 없으면 메인페이지로)

--- a/frontend/src/services/auth/api.ts
+++ b/frontend/src/services/auth/api.ts
@@ -45,7 +45,7 @@ export const verifyPhoneNumber = async (data: IVerifyPhoneReq): Promise<APIRespo
 };
 
 // 로그인 요청
-export const login = async (data: { account: string; password: string }): Promise<APIResponse<{ user: { account: string; password: string; }; }>> => {
+export const login = async (data: { account: string; password: string }): Promise<APIResponse<{ user: { account: string; password: string; role: string; }; }>> => {
   const response = await axiosCommonInstance.post('/auth/login', data);
 
   if (response.status === 200 && response.headers.authorization) {

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -9,6 +9,24 @@ export interface ISignUpFormValues extends ILoginFormValues {
   phone: string;
 }
 
+// 로그인 요청 타입
+export interface ILoginReq {
+  account: string;
+  password: string;
+}
+
+// 로그인 응답 타입
+export interface ILoginRes {
+  result: string;
+  data: {
+    user: {
+      nickname: string;
+      profileImageUrl: string;
+      role: string;
+    };
+  };
+}
+
 // 아이디 중복 검사 API 요청
 export interface ICheckIdReq {
   account: string;


### PR DESCRIPTION
<!-- Please check the one that applies to this PR using "x". -->

## 이슈
- #328 

## 어떤 이유로 MR를 하셨나요?
- feature 병합
- 버그 수정

<!-- 
 필요없는거 지우기
feat : 새로운 기능을 추가
fix : 버그 수정 또는 기능에 대한 큰 변화와 결과에 변화가 있을 때
docs : 문서 관련 커밋
refactor : 기능에 대한 변화 없이 리팩토링
style : 코드 스타일 변경(formatting, missing semi colons, …)
test : 테스트 관련 커밋
chore : 기타 커밋
-->

## 작업 사항

- refresh.ts의 로직을 수정했습니다.
- 이제 확실하게 "토큰이 없는 경우"에 대해 No Token에 대한 감지했을 때만 로그인 페이지로 리다이렉트함
- 리덕스 스토어 authSlice에 role 상태 관리를 추가했습니다. 로그인 했을 때 해당 유저의 권한을 확인합니다. (USER, OWNER)