### PR TITLE
[BE] fix #433: 예약 내역 조회 시 예약 상태 SUCCESS인지 확인

### DIFF
--- a/backend/src/main/java/com/d106/campu/reservation/repository/jpa/QReservationRepository.java
+++ b/backend/src/main/java/com/d106/campu/reservation/repository/jpa/QReservationRepository.java
@@ -2,6 +2,7 @@ package com.d106.campu.reservation.repository.jpa;
 
 import com.d106.campu.campsite.domain.jpa.Campsite;
 import com.d106.campu.campsite.domain.jpa.QCampsite;
+import com.d106.campu.reservation.constant.PaymentStatus;
 import com.d106.campu.reservation.domain.jpa.QReservation;
 import com.d106.campu.reservation.dto.ReservationDto;
 import com.d106.campu.room.domain.jpa.QRoom;
@@ -41,7 +42,8 @@ public class QReservationRepository {
         BooleanBuilder predicates = new BooleanBuilder()
             .and(campsite.eq(targetCampsite))
             .and(campsite.user.eq(owner))
-            .and(reservation.startDate.loe(today).and(reservation.endDate.goe(today)));
+            .and(reservation.startDate.loe(today).and(reservation.endDate.goe(today)))
+            .and(reservation.status.eq(PaymentStatus.SUCCESS));
 
         List<Tuple> tuples = jpaQueryFactory
             .select(projection)


### PR DESCRIPTION
## 이슈
- #433 

## 어떤 이유로 MR를 하셨나요?
- 버그 수정

## 작업 사항
- 캠핑장별 예약 내역 조회 시 예약 상태가 SUCCESS인지 확인하는 조건 추가

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.